### PR TITLE
Sans picocli

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ repositories {
 }
 
 dependencies {
-    annotationProcessor 'info.picocli:picocli-codegen:4.5.1'
-
-    implementation 'info.picocli:picocli:4.5.1'
+//    annotationProcessor 'info.picocli:picocli-codegen:4.5.1'
+//
+//    implementation 'info.picocli:picocli:4.5.1'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
@@ -24,9 +24,9 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.17.2'
 }
 
-compileJava {
-    options.compilerArgs += ["-Aproject=${project.group}/${project.name}"]
-}
+//compileJava {
+//    options.compilerArgs += ["-Aproject=${project.group}/${project.name}"]
+//}
 
 test {
     useJUnitPlatform()

--- a/src/main/java/org/mibuck/base64/Base64.java
+++ b/src/main/java/org/mibuck/base64/Base64.java
@@ -1,8 +1,5 @@
 package org.mibuck.base64;
 
-//import org.apache.commons.io.IOUtils;
-//import picocli.CommandLine;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -12,56 +9,14 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.function.Consumer;
 
-//Name
-//base64 - base64 encode/decode data and print to standard output
-//Synopsis
-//base64 [OPTION]... [FILE]
-//Description
-//
-//Base64 encode or decode FILE, or standard input, to standard output.
-//
-//-w, --wrap=COLS
-//    Wrap encoded lines after COLS character (default 76). Use 0 to disable line wrapping.
-//-d, --decode
-//    Decode data.
-//-i, --ignore-garbage
-//    When decoding, ignore non-alphabet characters.
-//--help
-//    display this help and exit
-//--version
-//    output version information and exit
-//
-//With no FILE, or when FILE is -, read standard input.
-//
-//The data are encoded as described for the base64 alphabet in RFC 3548. When decoding, the input may contain newlines in addition to the bytes of the formal base64 alphabet. Use --ignore-garbage to attempt to recover from any other non-alphabet bytes in the encoded stream.
-//// todo: create and use version provider to get the version from the .jar file but be careful of running from IDE as no jar will exist
-//@CommandLine.Command(
-//				name = "base64",
-//				description = "Encodes a file to Base64 or decodes a file from Base64.",
-//				version = "1.0",
-//				mixinStandardHelpOptions = true
-//
-//)
 public final class Base64 implements Runnable {
 
-//	@CommandLine.Parameters(
-//					index = "0",
-//					description = "The file to encode or decode",
-//					arity = "0..1"
-//	)
-//	private Path file;
-//
-//	@CommandLine.Option(
-//					names = {"-d", "--decode"},
-//					description = "Decode data. ",
-//					arity = "0..1",
-//					defaultValue = "false",
-//					fallbackValue = "true"
-//	)
-//	private boolean decode;
-
 	public static void main(String... args) {
-		new Base64(Parameters.valueOf(args)).run();
+		try {
+			new Base64(Parameters.valueOf(args)).run();
+		} catch (Throwable t) {
+			System.err.println(t.getLocalizedMessage());
+		}
 	}
 
 	private final Parameters parameters;
@@ -82,6 +37,10 @@ public final class Base64 implements Runnable {
 					break;
 
 				case DECODE:
+					final java.util.Base64.Decoder decoder = java.util.Base64.getDecoder();
+					try (final InputStream inputStream = decoder.wrap(System.in)) {
+						decoderConsumer(this.parameters.file()).accept(inputStream);
+					}
 					break;
 
 				default:
@@ -90,24 +49,6 @@ public final class Base64 implements Runnable {
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}
-	}
-
-	@Override
-	public Integer call() throws Exception {
-//		System.out.println("this = " + this);
-//		if (this.decode) {
-//			final java.util.Base64.Decoder decoder = java.util.Base64.getDecoder();
-//			try (final InputStream inputStream = decoder.wrap(System.in)) {
-//				decoderConsumer(this.file).accept(inputStream);
-//			}
-//		} else {
-//			final java.util.Base64.Encoder encoder = java.util.Base64.getEncoder();
-//			try (final OutputStream outputStream = encoder.wrap(System.out)) {
-//				encoderConsumer(this.file).accept(outputStream);
-//			}
-//		}
-
-		return 0;
 	}
 
 	private static Consumer<InputStream> decoderConsumer(final Path destination) {
@@ -149,12 +90,4 @@ public final class Base64 implements Runnable {
 			throw new UncheckedIOException(e);
 		}
 	}
-
-//	@Override
-//	public String toString() {
-//		return "Base64{" +
-//						"file=" + file +
-//						", decode=" + decode +
-//						'}';
-//	}
 }

--- a/src/main/java/org/mibuck/base64/Base64.java
+++ b/src/main/java/org/mibuck/base64/Base64.java
@@ -1,7 +1,7 @@
 package org.mibuck.base64;
 
 //import org.apache.commons.io.IOUtils;
-import picocli.CommandLine;
+//import picocli.CommandLine;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,7 +10,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
 //Name
@@ -35,50 +34,78 @@ import java.util.function.Consumer;
 //With no FILE, or when FILE is -, read standard input.
 //
 //The data are encoded as described for the base64 alphabet in RFC 3548. When decoding, the input may contain newlines in addition to the bytes of the formal base64 alphabet. Use --ignore-garbage to attempt to recover from any other non-alphabet bytes in the encoded stream.
-// todo: create and use version provider to get the version from the .jar file but be careful of running from IDE as no jar will exist
-@CommandLine.Command(
-				name = "base64",
-				description = "Encodes a file to Base64 or decodes a file from Base64.",
-				version = "1.0",
-				mixinStandardHelpOptions = true
+//// todo: create and use version provider to get the version from the .jar file but be careful of running from IDE as no jar will exist
+//@CommandLine.Command(
+//				name = "base64",
+//				description = "Encodes a file to Base64 or decodes a file from Base64.",
+//				version = "1.0",
+//				mixinStandardHelpOptions = true
+//
+//)
+public final class Base64 implements Runnable {
 
-)
-public final class Base64 implements Callable<Integer> {
-
-	@CommandLine.Parameters(
-					index = "0",
-					description = "The file to encode or decode",
-					arity = "0..1"
-	)
-	private Path file;
-
-	@CommandLine.Option(
-					names = {"-d", "--decode"},
-					description = "Decode data. ",
-					arity = "0..1",
-					defaultValue = "false",
-					fallbackValue = "true"
-	)
-	private boolean decode;
+//	@CommandLine.Parameters(
+//					index = "0",
+//					description = "The file to encode or decode",
+//					arity = "0..1"
+//	)
+//	private Path file;
+//
+//	@CommandLine.Option(
+//					names = {"-d", "--decode"},
+//					description = "Decode data. ",
+//					arity = "0..1",
+//					defaultValue = "false",
+//					fallbackValue = "true"
+//	)
+//	private boolean decode;
 
 	public static void main(String... args) {
-		new CommandLine(new Base64()).execute(args);
+		new Base64(Parameters.valueOf(args)).run();
+	}
+
+	private final Parameters parameters;
+
+	public Base64(Parameters parameters) {
+		this.parameters = parameters;
+	}
+
+	@Override
+	public void run() {
+		try {
+			switch (this.parameters.mode()) {
+				case ENCODE:
+					final java.util.Base64.Encoder encoder = java.util.Base64.getEncoder();
+					try (final OutputStream outputStream = encoder.wrap(System.out)) {
+						encoderConsumer(parameters.file()).accept(outputStream);
+					}
+					break;
+
+				case DECODE:
+					break;
+
+				default:
+					throw new UnsupportedOperationException(String.valueOf(this.parameters.mode()));
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
 	}
 
 	@Override
 	public Integer call() throws Exception {
 //		System.out.println("this = " + this);
-		if (this.decode) {
-			final java.util.Base64.Decoder decoder = java.util.Base64.getDecoder();
-			try (final InputStream inputStream = decoder.wrap(System.in)) {
-				decoderConsumer(this.file).accept(inputStream);
-			}
-		} else {
-			final java.util.Base64.Encoder encoder = java.util.Base64.getEncoder();
-			try (final OutputStream outputStream = encoder.wrap(System.out)) {
-				encoderConsumer(this.file).accept(outputStream);
-			}
-		}
+//		if (this.decode) {
+//			final java.util.Base64.Decoder decoder = java.util.Base64.getDecoder();
+//			try (final InputStream inputStream = decoder.wrap(System.in)) {
+//				decoderConsumer(this.file).accept(inputStream);
+//			}
+//		} else {
+//			final java.util.Base64.Encoder encoder = java.util.Base64.getEncoder();
+//			try (final OutputStream outputStream = encoder.wrap(System.out)) {
+//				encoderConsumer(this.file).accept(outputStream);
+//			}
+//		}
 
 		return 0;
 	}
@@ -102,7 +129,7 @@ public final class Base64 implements Callable<Integer> {
 			return outputStream -> copy(System.in, outputStream);
 		}
 
-		return outputStream ->  {
+		return outputStream -> {
 			try {
 				Files.copy(source, outputStream);
 			} catch (IOException e) {
@@ -123,11 +150,11 @@ public final class Base64 implements Callable<Integer> {
 		}
 	}
 
-	@Override
-	public String toString() {
-		return "Base64{" +
-						"file=" + file +
-						", decode=" + decode +
-						'}';
-	}
+//	@Override
+//	public String toString() {
+//		return "Base64{" +
+//						"file=" + file +
+//						", decode=" + decode +
+//						'}';
+//	}
 }

--- a/src/main/java/org/mibuck/base64/Parameters.java
+++ b/src/main/java/org/mibuck/base64/Parameters.java
@@ -1,0 +1,57 @@
+package org.mibuck.base64;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+public final class Parameters {
+
+	public enum Mode {
+		DECODE,
+		ENCODE;
+	}
+
+	public static Parameters valueOf(final String... args) {
+		Objects.requireNonNull(args, "Specified args cannot be null.");
+
+		Mode mode = Mode.ENCODE;
+		Path file = null;
+
+		for (String arg : args) {
+			final String stripped = arg.strip();
+			if ("-d".equals(stripped)) {
+				mode = Mode.DECODE;
+			} else {
+				file = Paths.get(arg);
+			}
+		}
+
+		if (file == null) {
+			usage();
+			System.exit(-1);
+		}
+
+		return new Parameters(mode, file);
+	}
+
+	private static void usage() {
+		// todo: implement
+		throw new UnsupportedOperationException();
+	}
+
+	private final Mode mode;
+	private final Path file;
+
+	private Parameters(Mode mode, Path file) {
+		this.mode = mode;
+		this.file = file;
+	}
+
+	public Mode mode() {
+		return mode;
+	}
+
+	public Path file() {
+		return file;
+	}
+}

--- a/src/main/java/org/mibuck/base64/Parameters.java
+++ b/src/main/java/org/mibuck/base64/Parameters.java
@@ -1,57 +1,93 @@
 package org.mibuck.base64;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
 public final class Parameters {
+  private static final String USAGE_TEXT =
+      "base64 - base64 encode/decode data and print to standard output\n" +
+          "Synopsis\n" +
+          "base64 [OPTION]... [FILE]\n" +
+          "Description\n" +
+          "\n" +
+          "Base64 encode or decode FILE, or standard input, to standard output.\n" +
+          "\n" +
+//          "-w, --wrap=COLS\n" +
+//          "    Wrap encoded lines after COLS character (default 76). Use 0 to disable line wrapping.\n" +
+          "-d, --decode\n" +
+          "    Decode data.\n" +
+//          "-i, --ignore-garbage\n" +
+//          "    When decoding, ignore non-alphabet characters.\n" +
+          "--help\n" +
+          "    display this help and exit\n" +
+          "--version\n" +
+          "    output version information and exit\n" +
+          "\n" +
+          "With no FILE, or when FILE is -, read standard input.\n" +
+          "\n" +
+          "The data are encoded as described for the base64 alphabet in RFC 3548. When decoding, the input may contain newlines in addition to the bytes of the formal base64 alphabet. Use --ignore-garbage to attempt to recover from any other non-alphabet bytes in the encoded stream.\n";
 
-	public enum Mode {
-		DECODE,
-		ENCODE;
-	}
+  public enum Mode {
+    DECODE,
+    ENCODE;
+  }
 
-	public static Parameters valueOf(final String... args) {
-		Objects.requireNonNull(args, "Specified args cannot be null.");
+  public static Parameters valueOf(final String... args) {
+    Objects.requireNonNull(args, "Specified args cannot be null.");
 
-		Mode mode = Mode.ENCODE;
-		Path file = null;
+    Mode mode = Mode.ENCODE;
+    Path file = null;
 
-		for (String arg : args) {
-			final String stripped = arg.strip();
-			if ("-d".equals(stripped)) {
-				mode = Mode.DECODE;
-			} else {
-				file = Paths.get(arg);
-			}
-		}
+    for (String arg : args) {
+      final String stripped = arg.strip();
+      if ("-d".equals(stripped)) {
+        mode = Mode.DECODE;
+      } else if ("--version".equals(arg)) {
+        displayVersion();
+        System.exit(0);
+      } else if ("--help".equals(arg)) {
+        usage();
+        System.exit(0);
+      } else {
+        if (!"-".equals(arg)) {
+          file = Paths.get(arg);
+        }
+      }
+    }
 
-		if (file == null) {
-			usage();
-			System.exit(-1);
-		}
+    if (mode == Mode.ENCODE && file != null && Files.notExists(file)) {
+      System.err.println(file + " does not exist.");
+      usage();
+      System.exit(-1);
+    }
 
-		return new Parameters(mode, file);
-	}
+    return new Parameters(mode, file);
+  }
 
-	private static void usage() {
-		// todo: implement
-		throw new UnsupportedOperationException();
-	}
+  private static void displayVersion() {
+    // todo: get from jar / manifest file?
+    System.out.println("base64 v1.00.00");
+  }
 
-	private final Mode mode;
-	private final Path file;
+  private static void usage() {
+    System.out.println(USAGE_TEXT);
+  }
 
-	private Parameters(Mode mode, Path file) {
-		this.mode = mode;
-		this.file = file;
-	}
+  private final Mode mode;
+  private final Path file;
 
-	public Mode mode() {
-		return mode;
-	}
+  private Parameters(Mode mode, Path file) {
+    this.mode = mode;
+    this.file = file;
+  }
 
-	public Path file() {
-		return file;
-	}
+  public Mode mode() {
+    return mode;
+  }
+
+  public Path file() {
+    return file;
+  }
 }


### PR DESCRIPTION
This removes the use of the Picocli library thus reducing base64's jar size from 355K to 6K.